### PR TITLE
[feat] 정적 컨텐츠 적용

### DIFF
--- a/hello-spring/src/main/resources/static/hello-static.html
+++ b/hello-spring/src/main/resources/static/hello-static.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>static content</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+정적 컨텐츠 입니다.
+</body>
+</html>


### PR DESCRIPTION
1) Static Content
By default, Spring Boot serves static content from a directory called /static (or /public or /resources or /META-INF/resources) in the classpath or from the root of the ServletContext. It uses the ResourceHttpRequestHandler from Spring MVC so that you can modify that behavior by adding your own WebMvcConfigurer and overriding the addResourceHandlers method.

:: 프로그래밍 불가, 정적 컨텐츠를 보여주기만 가능

2) resource/static/hello-static

3)  http://localhost:8082/hello-static.html